### PR TITLE
Start test example on 80

### DIFF
--- a/local.json
+++ b/local.json
@@ -1,7 +1,7 @@
 {
   "server": {
-    "port": 8080,
-    "siteUrl": "http://external_ip/"
+    "port": 80,
+    "siteUrl": "http://external_ip:8080/"
   }
 }
 


### PR DESCRIPTION
And conviently have docserver on 8080 port
Problem with doc server on custom port fixed in 4.3.0