### PR TITLE
Force api url of web-apps

### DIFF
--- a/local.json
+++ b/local.json
@@ -1,7 +1,9 @@
 {
   "server": {
     "port": 80,
-    "siteUrl": "http://external_ip:8080/"
+    "siteUrl": "http://external_ip:8080/",
+    "apiUrl": "web-apps/apps/api/documents/api.js",
+    "preloaderUrl": "web-apps/apps/api/documents/cache-scripts.html"
   }
 }
 


### PR DESCRIPTION
Some configs (like `onlyoffice-documentserver-integration`) force private `web-apps-pro`