### PR TITLE
Add cloning submodules from repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10-buster
 
 ARG build_branch=master
                                         
-RUN git clone -b $build_branch https://github.com/ONLYOFFICE/document-server-integration.git
+RUN git clone --depth=1 --recursive --shallow-submodules -b $build_branch https://github.com/ONLYOFFICE/document-server-integration.git
 WORKDIR /document-server-integration/web/documentserver-example/nodejs/
 RUN npm install
 ENV NODE_CONFIG_DIR="./config"


### PR DESCRIPTION
Since
https://github.com/ONLYOFFICE/document-server-integration/commit/3bf8952b1af9d9f13236e8f679cb050fd341cf32
This repo used submodules for storing new empty documents